### PR TITLE
Fix options fallback and add test

### DIFF
--- a/bot/common/service.py
+++ b/bot/common/service.py
@@ -34,12 +34,14 @@ class Service(Generic[TModel]):
 
         logger.debug(f"Building query for {self.model.__name__}")
 
-        if options is None:
-            options = tuple(self.options) if self.options else ()
-        elif not isinstance(options, (Iterable, Sequence)):
-            options = (options,)
+        if options is True:
+            options = self.options
 
-        stmt = stmt.options(*options)
+        if options is not None:
+            if isinstance(options, Iterable) and not isinstance(options, ExecutableOption):
+                stmt = stmt.options(*options)
+            else:
+                stmt = stmt.options(options)
 
         if filters:
             stmt = stmt.filter(*filters)

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -1,0 +1,21 @@
+import sys
+from pathlib import Path
+
+import pytest
+from sqlalchemy.orm import load_only
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from bot.common.service import Service
+from bot.models.user import User
+
+
+class UserService(Service[User]):
+    model = User
+    options = [load_only(User.id)]
+
+def test_custom_option_list_uses_passed_options():
+    service = UserService()
+    custom = [load_only(User.username)]
+    stmt = service._build_get_query(options=custom)
+    assert stmt._with_options == tuple(custom)


### PR DESCRIPTION
## Summary
- adjust `_build_get_query` to only use default `self.options` when the `options` argument is `True`
- preserve passed iterables or `ExecutableOption` objects unmodified
- add unit test covering custom option list usage

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ad1c332a48322b4cc512f25f16806